### PR TITLE
Issue #286: --out_dir doesn't honor relative paths

### DIFF
--- a/lib/cmds/clean.ts
+++ b/lib/cmds/clean.ts
@@ -11,7 +11,8 @@ import {Opts} from './opts';
 let prog = new Program()
                .command('clean', 'removes all downloaded driver files from the out_dir')
                .action(clean)
-               .addOption(Opts[Opt.OUT_DIR]);
+               .addOption(Opts[Opt.OUT_DIR])
+               .addOption(Opts[Opt.OUT_DIR_FROM_CWD]);
 
 export var program = prog;
 
@@ -33,8 +34,11 @@ function clean(options: Options): void {
     if (path.isAbsolute(options[Opt.OUT_DIR].getString())) {
       outputDir = options[Opt.OUT_DIR].getString();
     } else {
-      outputDir = path.resolve(Config.getBaseDir(), options[Opt.OUT_DIR].getString());
+      outputDir = path.resolve(
+          Config.getBaseDir(options[Opt.OUT_DIR_FROM_CWD].getBoolean()),
+          options[Opt.OUT_DIR].getString());
     }
+    Config.seleniumDir = outputDir;
   }
   FileManager.removeExistingFiles(outputDir);
 }

--- a/lib/cmds/opts.ts
+++ b/lib/cmds/opts.ts
@@ -3,6 +3,7 @@ import {Cli, Option, Options} from '../cli';
 import {Config} from '../config';
 
 export const OUT_DIR = 'out_dir';
+export const OUT_DIR_FROM_CWD = 'relativeFromCwd';
 export const SELENIUM_PORT = 'seleniumPort';
 export const APPIUM_PORT = 'appium-port';
 export const AVD_PORT = 'avd-port';
@@ -44,6 +45,9 @@ export const ALREADY_OFF_ERROR = 'already-off-error';
  */
 var opts: Options = {};
 opts[OUT_DIR] = new Option(OUT_DIR, 'Location to output/expect', 'string', Config.getSeleniumDir());
+opts[OUT_DIR_FROM_CWD] = new Option(
+    OUT_DIR, 'Whether the out_dir option is relative to the current working directory', 'boolean',
+    false);
 opts[SELENIUM_PORT] =
     new Option(SELENIUM_PORT, 'Optional port for the selenium standalone server', 'string', '4444');
 opts[APPIUM_PORT] =

--- a/lib/cmds/start.ts
+++ b/lib/cmds/start.ts
@@ -22,6 +22,7 @@ let prog = new Program()
                .command(commandName, 'start up the selenium server')
                .action(start)
                .addOption(Opts[Opt.OUT_DIR])
+               .addOption(Opts[Opt.OUT_DIR_FROM_CWD])
                .addOption(Opts[Opt.SELENIUM_PORT])
                .addOption(Opts[Opt.APPIUM_PORT])
                .addOption(Opts[Opt.AVD_PORT])
@@ -83,8 +84,11 @@ function start(options: Options) {
     if (path.isAbsolute(options[Opt.OUT_DIR].getString())) {
       outputDir = options[Opt.OUT_DIR].getString();
     } else {
-      outputDir = path.resolve(Config.getBaseDir(), options[Opt.OUT_DIR].getString());
+      outputDir = path.resolve(
+          Config.getBaseDir(options[Opt.OUT_DIR_FROM_CWD].getBoolean()),
+          options[Opt.OUT_DIR].getString());
     }
+    Config.seleniumDir = outputDir;
   }
 
   try {

--- a/lib/cmds/status.ts
+++ b/lib/cmds/status.ts
@@ -9,12 +9,14 @@ import {Config} from '../config';
 import {FileManager} from '../files';
 
 import * as Opt from './';
+import {OUT_DIR_FROM_CWD} from './';
 import {Opts} from './opts';
 
 let logger = new Logger('status');
 let prog = new Program()
                .command('status', 'list the current available drivers')
                .addOption(Opts[Opt.OUT_DIR])
+               .addOption(Opts[OUT_DIR_FROM_CWD])
                .action(status);
 
 export var program = prog;
@@ -38,8 +40,11 @@ function status(options: Options) {
     if (path.isAbsolute(options[Opt.OUT_DIR].getString())) {
       outputDir = options[Opt.OUT_DIR].getString();
     } else {
-      outputDir = path.resolve(Config.getBaseDir(), options[Opt.OUT_DIR].getString());
+      outputDir = path.resolve(
+          Config.getBaseDir(options[Opt.OUT_DIR_FROM_CWD].getBoolean()),
+          options[Opt.OUT_DIR].getString());
     }
+    Config.seleniumDir = outputDir;
   }
 
   try {

--- a/lib/cmds/update.ts
+++ b/lib/cmds/update.ts
@@ -24,6 +24,7 @@ let prog = new Program()
                .command('update', 'install or update selected binaries')
                .action(update)
                .addOption(Opts[Opt.OUT_DIR])
+               .addOption(Opts[Opt.OUT_DIR_FROM_CWD])
                .addOption(Opts[Opt.VERBOSE])
                .addOption(Opts[Opt.IGNORE_SSL])
                .addOption(Opts[Opt.PROXY])
@@ -108,8 +109,11 @@ function update(options: Options): Promise<void> {
     if (path.isAbsolute(options[Opt.OUT_DIR].getString())) {
       outputDir = options[Opt.OUT_DIR].getString();
     } else {
-      outputDir = path.resolve(Config.getBaseDir(), options[Opt.OUT_DIR].getString());
+      outputDir = path.resolve(
+          Config.getBaseDir(options[Opt.OUT_DIR_FROM_CWD].getBoolean()),
+          options[Opt.OUT_DIR].getString());
     }
+    Config.seleniumDir = outputDir;
     FileManager.makeOutputDirectory(outputDir);
   }
   let ignoreSSL = options[Opt.IGNORE_SSL].getBoolean();

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,6 +36,8 @@ export class Config {
   static parentPath = path.resolve(Config.cwd, '..');
   static dir = __dirname;
   static folder = Config.cwd.replace(Config.parentPath, '').substring(1);
+  static seleniumDir =
+      process.env.SELENIUM_DIR || path.resolve(Config.dir, '..', '..', 'selenium/');
 
   static isProjectVersion = Config.folder === Config.nodeModuleName;
   static isLocalVersion = false;
@@ -75,10 +77,10 @@ export class Config {
   }
 
   static getSeleniumDir(): string {
-    return path.resolve(Config.dir, '..', '..', 'selenium/');
+    return Config.seleniumDir;
   }
-  static getBaseDir(): string {
-    return path.resolve(Config.dir, '..', '..');
+  static getBaseDir(useCwd: boolean = false): string {
+    return useCwd ? Config.cwd : path.resolve(Config.dir, '..', '..');
   }
 
   /**


### PR DESCRIPTION
- Make out_dir respected app-wide and add option for it to be relative.
- Add support for SELENIUM_DIR as an environment variable to indicate the selenium directory to use